### PR TITLE
[FIX] Domain term operator

### DIFF
--- a/addons/account_voucher/account_voucher.py
+++ b/addons/account_voucher/account_voucher.py
@@ -699,7 +699,7 @@ class account_voucher(osv.osv):
         }
 
         # drop existing lines
-        line_ids = ids and line_pool.search(cr, uid, [('voucher_id', '=', ids[0])])
+        line_ids = ids and line_pool.search(cr, uid, [('voucher_id', 'in', ids[0])])
         for line in line_pool.browse(cr, uid, line_ids, context=context):
             if line.type == 'cr':
                 default['value']['line_cr_ids'].append((2, line.id))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
 WARNING Chris_3_1 openerp.osv.expression: The domain term '('voucher_id', '=', [7251])' should use the 'in' or 'not in' operator.

Desired behavior after PR is merged:
Should not have warning.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Fix for operator, should be 'in', removes warning -  WARNING Chris_3_1 openerp.osv.expression: The domain term '('voucher_id', '=', [7251])' should use the 'in' or 'not in' operator.
