### PR TITLE
[FIX] base_import_module: allow selective access to module files

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -96,18 +96,23 @@ class view(osv.osv):
                     raise osv.except_osv(_('Error !'), msg % zf.filename)
 
             with openerp.tools.osutil.tempdir() as module_dir:
-                z.extractall(module_dir)
-                dirs = [d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))]
-                for mod_name in dirs:
-                    module_names.append(mod_name)
-                    try:
-                        # assert mod_name.startswith('theme_')
-                        path = opj(module_dir, mod_name)
-                        self.import_module(cr, uid, mod_name, path, force=force, context=context)
-                        success.append(mod_name)
-                    except Exception, e:
-                        _logger.exception('Error while importing module')
-                        errors[mod_name] = tools.ustr(e)
+                import openerp.modules as addons
+                try:
+                    addons.module.ad_paths.append(module_dir)
+                    z.extractall(module_dir)
+                    dirs = [d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))]
+                    for mod_name in dirs:
+                        module_names.append(mod_name)
+                        try:
+                            # assert mod_name.startswith('theme_')
+                            path = opj(module_dir, mod_name)
+                            self.import_module(cr, uid, mod_name, path, force=force, context=context)
+                            success.append(mod_name)
+                        except Exception, e:
+                            _logger.exception('Error while importing module')
+                            errors[mod_name] = tools.ustr(e)
+                finally:
+                    addons.module.ad_paths.remove(module_dir)
         r = ["Successfully imported module '%s'" % mod for mod in success]
         for mod, error in errors.items():
             r.append("Error while importing module '%s': %r" % (mod, error))


### PR DESCRIPTION
As a consequence of rev. 76cd8d2558d2a1fc11681dbc4a134ba06fb698c0,
imported modules were unable to access their resource files during
import.

Rather than further modifying the file_open API to whitelist paths
(the whole thing needs a redesign in master), we temporarily
whitelist the temporary directory by including it in the global
addons_paths, making sure to undo it afterwards.

This gives all lower level function access the resource files via
file_open, without having to pass around whitelisted paths
through many different calls.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
